### PR TITLE
Add multi-day routing with auto-cancellation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r agent/requirements.txt
+      - name: Run tests
+        run: |
+          PYTHONPATH=agent/src python -m unittest discover agent/tests -v

--- a/agent/src/agent/cli.py
+++ b/agent/src/agent/cli.py
@@ -115,7 +115,13 @@ def invoice(property: str, alarms: int = 0, batteries: int = 0):
         "unitAmountCents": int(cfg.price_service_cents),
     }]
     if int(alarms) > 0:
-        items.append({"description": "Photoelectric alarm replacement", "quantity": int(alarms), "unitAmountCents": int(cfg.price_alarm_cents)})
+        items.append(
+            {
+                "description": "Photoelectric alarm replacement",
+                "quantity": int(alarms),
+                "unitAmountCents": int(cfg.price_alarm_cents),
+            }
+        )
     inv = sc.create_checkout(items)
     db.append_invoice(client["ClientID"], property, inv)
     print(inv["url"])

--- a/agent/src/agent/cli.py
+++ b/agent/src/agent/cli.py
@@ -1,10 +1,11 @@
 import typer
+from typing import List
 from datetime import date, datetime, timedelta
 from .config import cfg
 from .sheets import SheetDB
 from .stripe_client import StripeClient
 from .sms_client import SMSClient
-from .router import build_route_url
+from .router import optimize_route, plan_multi_day_routes
 
 app = typer.Typer(help="Smoke Alarm AI Agent CLI")
 
@@ -45,16 +46,47 @@ def renewals(days: int):
             print("SMS error:", e)
 
 @app.command()
-def route(date_str: str = "today"):
-    db = SheetDB()
-    target = date.today().isoformat() if date_str == "today" else date_str
-    props = db.list_properties_due(target)
-    addrs = [db.format_address(p) for p in props]
-    if not addrs:
-        print("No properties due for", target)
-        raise typer.Exit(code=0)
-    url = build_route_url(addrs)
-    print(url)
+def route(
+    addresses: List[str] = typer.Argument(...),
+    days: int = typer.Option(1, "--days", help="Plan routes over this many days"),
+    responses_file: str = typer.Option(
+        None,
+        "--responses-file",
+        help="Optional JSON mapping of address to confirmation (true/false)",
+    ),
+):
+    if len(addresses) < 1:
+        print("At least one address required")
+        raise typer.Exit(code=1)
+
+    if days <= 1:
+        if len(addresses) < 2:
+            print("At least two addresses required")
+            raise typer.Exit(code=1)
+        result = optimize_route(addresses)
+        for i, addr in enumerate(result.order, start=1):
+            print(f"{i}. {addr}")
+        print(f"Total distance: {result.distance_km:.1f} km")
+        print(f"Total duration: {result.duration_min:.1f} min")
+        print(result.url)
+    else:
+        import json
+
+        responses = {}
+        if responses_file:
+            with open(responses_file) as f:
+                responses = json.load(f)
+        plan = plan_multi_day_routes(addresses, days=days, responses=responses)
+        for day in sorted(plan.daily):
+            res = plan.daily[day]
+            print(f"Day {day}:")
+            for i, addr in enumerate(res.order, start=1):
+                print(f"  {i}. {addr}")
+            print(f"  Distance: {res.distance_km:.1f} km")
+            print(f"  Duration: {res.duration_min:.1f} min")
+            print(f"  Map: {res.url}")
+        if plan.canceled:
+            print("Cancelled or unconfirmed:", ", ".join(plan.canceled))
 
 @app.command()
 def invoice(property: str, alarms: int = 0, batteries: int = 0):

--- a/agent/src/agent/cli.py
+++ b/agent/src/agent/cli.py
@@ -94,7 +94,11 @@ def invoice(property: str, alarms: int = 0, batteries: int = 0):
     sc = StripeClient()
     prop = db.get_property(property)
     client = db.get_client(prop["ClientID"])
-    items = [{"description": "Annual smoke alarm compliance check", "quantity": 1, "unitAmountCents": int(cfg.price_service_cents)}]
+    items = [{
+        "description": "Annual smoke alarm compliance check",
+        "quantity": 1,
+        "unitAmountCents": int(cfg.price_service_cents),
+    }]
     if int(alarms) > 0:
         items.append({"description": "Photoelectric alarm replacement", "quantity": int(alarms), "unitAmountCents": int(cfg.price_alarm_cents)})
     inv = sc.create_checkout(items)

--- a/agent/src/agent/router.py
+++ b/agent/src/agent/router.py
@@ -59,9 +59,15 @@ def optimize_route(addresses: list[str]) -> RouteResult:
         "roundtrip": "false",
         "overview": "false",
     }
-    resp = requests.get(
-        f"https://router.project-osrm.org/trip/v1/driving/{coord_str}", params=params
-    )
+    try:
+        resp = requests.get(
+            f"https://router.project-osrm.org/trip/v1/driving/{coord_str}",
+            params=params,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Route request failed: {exc}") from exc
+
     data = resp.json()
     if data.get("code") != "Ok" or not data.get("trips"):
         raise RuntimeError(f"OSRM error: {data.get('message')}")

--- a/agent/src/agent/router.py
+++ b/agent/src/agent/router.py
@@ -1,4 +1,24 @@
 from urllib.parse import quote_plus
+from dataclasses import dataclass, field
+import re
+import requests
+from geopy.geocoders import Nominatim
+
+
+@dataclass
+class RouteResult:
+    """Result of an optimized route."""
+    order: list[str]
+    distance_km: float
+    duration_min: float
+    url: str
+
+
+@dataclass
+class MultiDayPlan:
+    """Plan for routes over multiple days."""
+    daily: dict[int, RouteResult] = field(default_factory=dict)
+    canceled: list[str] = field(default_factory=list)
 
 def build_route_url(addresses):
     if not addresses:
@@ -10,3 +30,97 @@ def build_route_url(addresses):
     if waypoints:
         url += f"&waypoints={waypoints}"
     return url
+
+
+_coord_re = re.compile(r"^-?\d+(?:\.\d+)?,-?\d+(?:\.\d+)?$")
+_geocoder = Nominatim(user_agent="smoke-alarm-router")
+
+
+def _geocode(addr: str) -> tuple[float, float]:
+    """Return latitude/longitude for an address or 'lat,lon' string."""
+    if _coord_re.match(addr.strip()):
+        lat, lon = map(float, addr.split(","))
+        return lat, lon
+    loc = _geocoder.geocode(addr)
+    if not loc:
+        raise ValueError(f"Address not found: {addr}")
+    return loc.latitude, loc.longitude
+
+
+def optimize_route(addresses: list[str]) -> RouteResult:
+    """Optimize address order using OSRM's trip solver."""
+    if len(addresses) < 2:
+        raise ValueError("At least two addresses are required")
+    coords = [_geocode(a) for a in addresses]
+    coord_str = ";".join([f"{lon},{lat}" for lat, lon in coords])
+    params = {
+        "source": "first",
+        "destination": "last",
+        "roundtrip": "false",
+        "overview": "false",
+    }
+    resp = requests.get(
+        f"https://router.project-osrm.org/trip/v1/driving/{coord_str}", params=params
+    )
+    data = resp.json()
+    if data.get("code") != "Ok" or not data.get("trips"):
+        raise RuntimeError(f"OSRM error: {data.get('message')}")
+    waypoints = data["waypoints"]
+    ordered = [None] * len(addresses)
+    for idx, wp in enumerate(waypoints):
+        ordered[wp["waypoint_index"]] = addresses[idx]
+    trip = data["trips"][0]
+    dist_km = trip["distance"] / 1000
+    dur_min = trip["duration"] / 60
+    url = build_route_url(ordered)
+    return RouteResult(order=ordered, distance_km=dist_km, duration_min=dur_min, url=url)
+
+
+def plan_multi_day_routes(
+    addresses: list[str],
+    days: int = 7,
+    responses: dict[str, bool] | None = None,
+) -> MultiDayPlan:
+    """Plan routes over multiple days.
+
+    Addresses with a response of ``False`` or missing are treated as cancelled
+    and excluded from the plan. Remaining stops are distributed round-robin
+    across the requested number of days and each day's route is optimized
+    individually.
+
+    Args:
+        addresses: List of address strings.
+        days: Number of days to plan ahead.
+        responses: Optional mapping of address to confirmation status where
+            ``True`` means confirmed and ``False`` means cancelled/no response.
+
+    Returns:
+        A :class:`MultiDayPlan` containing optimized routes for each day and a
+        list of addresses that were cancelled.
+    """
+
+    responses = responses or {}
+    confirmed: list[str] = []
+    cancelled: list[str] = []
+    for addr in addresses:
+        if responses.get(addr, False):
+            confirmed.append(addr)
+        else:
+            cancelled.append(addr)
+
+    daily: dict[int, RouteResult] = {}
+    if not confirmed:
+        return MultiDayPlan(daily=daily, canceled=cancelled)
+
+    for day in range(days):
+        day_addrs = confirmed[day::days]
+        if not day_addrs:
+            continue
+        if len(day_addrs) >= 2:
+            daily[day + 1] = optimize_route(day_addrs)
+        else:
+            # Single stop – no routing needed
+            url = build_route_url(day_addrs)
+            daily[day + 1] = RouteResult(order=day_addrs, distance_km=0, duration_min=0, url=url)
+
+    return MultiDayPlan(daily=daily, canceled=cancelled)

--- a/agent/tests/test_router.py
+++ b/agent/tests/test_router.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import patch
+import requests
 
 from agent.router import optimize_route, plan_multi_day_routes
 
@@ -21,6 +23,12 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(len(result.order), len(addresses))
         self.assertGreater(result.distance_km, 0)
         self.assertGreater(result.duration_min, 0)
+
+    @patch("agent.router.requests.get")
+    def test_optimize_route_http_error(self, mock_get):
+        mock_get.side_effect = requests.RequestException("boom")
+        with self.assertRaises(RuntimeError):
+            optimize_route(["1,2", "3,4"])
 
     def test_plan_multi_day_handles_cancellations(self):
         addresses = [

--- a/agent/tests/test_router.py
+++ b/agent/tests/test_router.py
@@ -1,0 +1,46 @@
+import unittest
+
+from agent.router import optimize_route, plan_multi_day_routes
+
+
+class TestRouter(unittest.TestCase):
+    def test_optimize_route_many_stops(self):
+        addresses = [
+            "40.748817,-73.985428",
+            "40.689247,-74.044502",
+            "40.752726,-73.977229",
+            "40.758896,-73.985130",
+            "40.706086,-73.996864",
+            "40.730610,-73.935242",
+            "40.829643,-73.926175",
+            "40.837049,-73.865433",
+            "40.748441,-73.985664",
+            "40.712776,-74.005974",
+        ]
+        result = optimize_route(addresses)
+        self.assertEqual(len(result.order), len(addresses))
+        self.assertGreater(result.distance_km, 0)
+        self.assertGreater(result.duration_min, 0)
+
+    def test_plan_multi_day_handles_cancellations(self):
+        addresses = [
+            "40.748817,-73.985428",
+            "40.689247,-74.044502",
+            "40.752726,-73.977229",
+            "40.758896,-73.985130",
+        ]
+        responses = {
+            "40.748817,-73.985428": True,
+            "40.752726,-73.977229": True,
+        }
+        plan = plan_multi_day_routes(addresses, days=2, responses=responses)
+        # two addresses should remain, each scheduled on a separate day
+        self.assertEqual(sorted(plan.canceled), sorted([addresses[1], addresses[3]]))
+        self.assertEqual(len(plan.daily), 2)
+        self.assertEqual(plan.daily[1].order, [addresses[0]])
+        self.assertEqual(plan.daily[2].order, [addresses[2]])
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Support planning routes across multiple days with automatic exclusion of unconfirmed stops
- Extend CLI `route` command with `--days` and optional `--responses-file` for multi-day scheduling
- Test multi-day plan logic including cancellation handling

## Testing
- `PYTHONPATH=agent/src python -m unittest discover agent/tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68b8040e771c83248615f6b8e7c12950