### PR TITLE
refactor: make SheetDB address formatter static

### DIFF
--- a/agent/src/agent/sheets.py
+++ b/agent/src/agent/sheets.py
@@ -76,6 +76,14 @@ class SheetDB:
         ]
         self._append("Invoices", [row])
 
-    def format_address(self, p: dict):
-        parts = [p.get("AddressLine1",""), p.get("AddressLine2",""), p.get("Suburb",""), p.get("Postcode",""), p.get("State","")]
-        return ", ".join([x for x in parts if x])
+    @staticmethod
+    def format_address(p: dict) -> str:
+        """Return a single-line address from property fields."""
+        parts = [
+            p.get("AddressLine1", ""),
+            p.get("AddressLine2", ""),
+            p.get("Suburb", ""),
+            p.get("Postcode", ""),
+            p.get("State", ""),
+        ]
+        return ", ".join(x for x in parts if x)

--- a/agent/tests/test_sheets.py
+++ b/agent/tests/test_sheets.py
@@ -1,0 +1,10 @@
+from agent.sheets import SheetDB
+
+def test_format_address():
+    data = {
+        "AddressLine1": "1 Main St",
+        "Suburb": "Springfield",
+        "Postcode": "1234",
+        "State": "NSW",
+    }
+    assert SheetDB.format_address(data) == "1 Main St, Springfield, 1234, NSW"


### PR DESCRIPTION
## Summary
- make `SheetDB.format_address` a static method
- cover address formatting with a unit test

## Testing
- `PYTHONPATH=agent/src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86cc639c08324b8ba8f0ba3a1437f