### PR TITLE
feat(gui): improve mobile accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Alternatively, use the convenience scripts from the repository root:
 - Linux/macOS: `./scripts/start_gui.sh`
 - Windows: `scripts\start_gui.bat`
 
+These scripts expose the dev server on your network and print a URL that can be opened on a phone.
 
  main
 Run the component tests with:

--- a/gui/README.md
+++ b/gui/README.md
@@ -7,7 +7,7 @@ A React + TypeScript operator console for planning routes, recording visits, and
 ./scripts/launch_gui.sh
 ```
 
-The script installs dependencies, starts the development server, and attempts to create a desktop shortcut for quick access.
+The script installs dependencies, starts the development server, and attempts to create a desktop shortcut for quick access. It also binds the server to your network interface and prints a URL you can open on your phone.
 
 ## Testing
 ```bash

--- a/gui/index.html
+++ b/gui/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>Smoke Alarm Console</title>
   </head>
   <body class="bg-background text-foreground">

--- a/gui/src/components/AppShell.tsx
+++ b/gui/src/components/AppShell.tsx
@@ -1,15 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
 import { SidebarNav } from "./SidebarNav";
 import { TopBar } from "./TopBar";
 
 export function AppShell() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <div className="min-h-screen flex bg-gray-900 text-gray-100">
-      <aside className="w-56 border-r border-gray-800 p-4">
+      <aside
+        id="sidebar"
+        className={`fixed inset-y-0 left-0 w-56 bg-gray-900 border-r border-gray-800 p-4 transition-transform transform md:relative md:translate-x-0 md:transform-none ${menuOpen ? "translate-x-0" : "-translate-x-full"}`}
+      >
         <SidebarNav />
       </aside>
-      <div className="flex-1 flex flex-col">
-        <TopBar />
+      {menuOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 md:hidden"
+          onClick={() => setMenuOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+      <div className="flex-1 flex flex-col md:ml-56">
+        <TopBar menuOpen={menuOpen} onMenuClick={() => setMenuOpen((o) => !o)} />
         <main id="main" className="flex-1 p-4">
           Welcome to Smoke Alarm Console
         </main>

--- a/gui/src/components/TopBar.tsx
+++ b/gui/src/components/TopBar.tsx
@@ -1,19 +1,36 @@
 import React from "react";
-import { Sun, Moon } from "lucide-react";
+import { Sun, Moon, Menu } from "lucide-react";
 import { useTheme } from "./ThemeProvider";
 
-export function TopBar() {
+interface TopBarProps {
+  onMenuClick: () => void;
+  menuOpen: boolean;
+}
+
+export function TopBar({ onMenuClick, menuOpen }: TopBarProps) {
   const { theme, toggle } = useTheme();
 
   return (
-    <header className="flex items-center justify-between border-b border-gray-700 p-4">
-      <input
-        type="text"
-        aria-label="Search"
-        placeholder="Search..."
-        className="bg-gray-800 text-white rounded px-2 py-1 w-64 focus:outline-none focus:ring"
-      />
-      <div className="flex items-center gap-2">
+    <header className="flex items-center justify-between border-b border-gray-700 p-4 pt-[env(safe-area-inset-top)]">
+      <div className="flex items-center gap-2 flex-1">
+        <button
+          type="button"
+          aria-label="Toggle menu"
+          aria-expanded={menuOpen}
+          aria-controls="sidebar"
+          onClick={onMenuClick}
+          className="md:hidden bg-gray-700 text-white p-1 rounded"
+        >
+          <Menu className="h-4 w-4" />
+        </button>
+        <input
+          type="text"
+          aria-label="Search"
+          placeholder="Search..."
+          className="bg-gray-800 text-white rounded px-2 py-1 w-full md:w-64 focus:outline-none focus:ring"
+        />
+      </div>
+      <div className="flex items-center gap-2 ml-2">
         <button
           type="button"
           className="bg-gray-700 text-white px-3 py-1 rounded"

--- a/scripts/launch_gui.sh
+++ b/scripts/launch_gui.sh
@@ -5,15 +5,20 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUI_DIR="$SCRIPT_DIR/../gui"
 PORT=5173
+HOST=0.0.0.0
 
 cd "$GUI_DIR"
 npm install --no-package-lock
-npm run dev &
+npm run dev -- --host "$HOST" &
 SERVER_PID=$!
 
 # Give the server a moment to start
 sleep 2
 URL="http://localhost:$PORT"
+LOCAL_IP=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
+if [ -n "$LOCAL_IP" ]; then
+  echo "Access the GUI from other devices on the network: http://$LOCAL_IP:$PORT"
+fi
 
 # Open the application in the default browser
 if command -v xdg-open >/dev/null 2>&1; then

--- a/scripts/start_gui.bat
+++ b/scripts/start_gui.bat
@@ -2,7 +2,16 @@
 REM Launch the Smoke Alarm GUI development server.
 set SCRIPT_DIR=%~dp0
 cd /d "%SCRIPT_DIR%..\gui"
+
+set PORT=5173
+set HOST=0.0.0.0
+
 if not exist node_modules (
   npm install
 )
-npm run dev
+
+for /f "tokens=2 delims=:" %%A in ('ipconfig ^| findstr /R /C:"IPv4.*" ^| findstr /V "127.0.0.1"') do set IP=%%A
+set IP=%IP: =%
+if not "%IP%"=="" echo Access the GUI from other devices on the network: http://%IP%:%PORT%
+
+npm run dev -- --host %HOST%

--- a/scripts/start_gui.sh
+++ b/scripts/start_gui.sh
@@ -4,8 +4,17 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUI_DIR="$SCRIPT_DIR/../gui"
+PORT=5173
+HOST=0.0.0.0
+
 cd "$GUI_DIR"
 if [ ! -d node_modules ]; then
   npm install
 fi
-npm run dev
+
+LOCAL_IP=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
+if [ -n "$LOCAL_IP" ]; then
+  echo "Access the GUI from other devices on the network: http://$LOCAL_IP:$PORT"
+fi
+
+npm run dev -- --host "$HOST"


### PR DESCRIPTION
## Summary
- expose GUI dev server on local network for mobile devices
- document how to launch the console and retrieve a phone-friendly URL
- add `aria-expanded` and `aria-controls` to the mobile menu toggle

## Testing
- `pre-commit run --files README.md gui/README.md gui/src/components/AppShell.tsx gui/src/components/TopBar.tsx scripts/launch_gui.sh scripts/start_gui.sh scripts/start_gui.bat`
- `cd gui && npm install`
- `cd gui && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b86e9352f0832485e6312f529998c3