### PR TITLE
feat: add pricing page with trial gating

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -4,6 +4,8 @@ import { AppShell } from "./components/AppShell";
 import { ClientPortal } from "./components/ClientPortal";
 import { AdminPanel } from "./components/AdminPanel";
 import { ThemeProvider } from "./components/ThemeProvider";
+import { PricingPage } from "./components/PricingPage";
+import { TrialGuard } from "./components/TrialGuard";
 
 export default function App() {
   return (
@@ -16,7 +18,15 @@ export default function App() {
           Skip to content
         </a>
         <Routes>
-          <Route path="/" element={<AppShell />} />
+          <Route
+            path="/"
+            element={
+              <TrialGuard>
+                <AppShell />
+              </TrialGuard>
+            }
+          />
+          <Route path="/pricing" element={<PricingPage />} />
           <Route path="/client" element={<ClientPortal />} />
           <Route path="/admin" element={<AdminPanel />} />
         </Routes>

--- a/gui/src/__tests__/App.test.tsx
+++ b/gui/src/__tests__/App.test.tsx
@@ -1,11 +1,17 @@
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import React from "react";
 import App from "../App";
 
 describe("App", () => {
-  afterEach(() => cleanup());
+  beforeEach(() => {
+    window.localStorage.setItem("trialActive", "true");
+  });
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
 
   it("renders navigation and search", () => {
     window.history.pushState({}, "", "/");

--- a/gui/src/__tests__/Pricing.test.tsx
+++ b/gui/src/__tests__/Pricing.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import React from "react";
+import App from "../App";
+
+describe("Pricing and trial gating", () => {
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+
+  it("redirects to pricing when trial inactive", () => {
+    window.history.pushState({}, "", "/");
+    render(<App />);
+    expect(screen.getByText("Pricing")).toBeInTheDocument();
+  });
+
+  it("starts trial and shows app shell", () => {
+    window.history.pushState({}, "", "/pricing");
+    render(<App />);
+    fireEvent.click(screen.getByText("Start Free Trial"));
+    expect(screen.getByText(/Smoke Alarm Console/)).toBeInTheDocument();
+  });
+});

--- a/gui/src/components/PricingPage.tsx
+++ b/gui/src/components/PricingPage.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+export function PricingPage() {
+  const navigate = useNavigate();
+  const startTrial = () => {
+    window.localStorage.setItem("trialActive", "true");
+    navigate("/");
+  };
+  return (
+    <main className="min-h-screen p-4 bg-white text-gray-900">
+      <h1 className="text-2xl font-bold mb-4">Pricing</h1>
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="border rounded p-4">
+          <h2 className="text-xl font-semibold">Free Trial</h2>
+          <p className="mt-2">14 days full access.</p>
+          <button
+            type="button"
+            onClick={startTrial}
+            className="mt-4 bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            Start Free Trial
+          </button>
+        </div>
+        <div className="border rounded p-4">
+          <h2 className="text-xl font-semibold">Pro</h2>
+          <p className="mt-2">$29/month after trial.</p>
+        </div>
+        <div className="border rounded p-4">
+          <h2 className="text-xl font-semibold">Enterprise</h2>
+          <p className="mt-2">Contact us for volume pricing.</p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/gui/src/components/TrialGuard.tsx
+++ b/gui/src/components/TrialGuard.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+
+interface TrialGuardProps {
+  children: React.ReactElement;
+}
+
+export function TrialGuard({ children }: TrialGuardProps) {
+  const active =
+    typeof window !== "undefined" &&
+    window.localStorage.getItem("trialActive") === "true";
+  if (!active) {
+    return <Navigate to="/pricing" replace />;
+  }
+  return children;
+}


### PR DESCRIPTION
## Summary
- add public pricing page with free trial call to action
- gate main app behind a trial check
- test trial activation and app routing

## Testing
- `npm test`
- `PYTHONPATH=agent/src python -m unittest discover agent/tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68b8e742faec83248152914d4f521b90