### PR TITLE
chore: add AGENTS guidance for coding agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+Repository instructions for GitHub Copilot
+
+Use the root AGENTS.md as the source of truth for setup, build, test, lint, type check, routing, and PR rules.
+
+Key invariants
+
+Rebase on origin/main before push
+
+No conflict markers
+
+Run preflight and keep PRs small
+
+Entry points
+
+CLI python -m agent.cli route ...
+
+UI streamlit run gui/streamlit_app.py
+
+When proposing changes
+
+Explain plan
+
+Run tests and include artifacts such as plan samples and pdf samples
+
+Follow Conventional Commits

--- a/.github/instructions/gui.instructions.md
+++ b/.github/instructions/gui.instructions.md
@@ -1,0 +1,5 @@
+applies_to:
+
+"gui/**"
+
+Do not hardcode secrets. Keep network calls in helper modules. Aim for fast startup. Provide sample data path and offline mode for demos.

--- a/.github/instructions/optimizer.instructions.md
+++ b/.github/instructions/optimizer.instructions.md
@@ -1,0 +1,5 @@
+applies_to:
+
+"agent/src/agent/optimizer/**"
+
+Keep OR-Tools constraints correct. Use OSRM /table for matrices only through services/osrm.py. Add tests under agent/tests/optimizer. Cache matrices by day where possible. Keep functions small and pure and fully typed.

--- a/.github/instructions/services.instructions.md
+++ b/.github/instructions/services.instructions.md
@@ -1,0 +1,5 @@
+applies_to:
+
+"agent/src/agent/services/**"
+
+HTTP calls must have timeouts, retries, and proper headers. Respect geocode rate limit. Never commit secrets. Add mocks for tests. Use Pydantic models for IO.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,141 @@
+AGENTS.md
+
+Purpose: give coding agents one predictable place to learn how to build, test, lint, type check, route, and ship work in this repo without breaking things. Keep human onboarding in README.md.
+
+Project profile
+
+Name: Smoke-Alarm
+
+Language: Python 3.11 or newer
+
+Domain: smoke alarm compliance operations in Victoria AU
+
+Top folders
+
+agent Python package for CLI, services, optimizer, reports
+
+gui Dispatcher UI
+
+docs Runbooks and architecture notes
+
+.github/workflows CI
+
+scripts Local helpers
+
+templates Report templates
+
+apps_script Google Apps Script assets
+
+Golden rules
+
+Rebase on origin/main before any push.
+
+Never commit conflict markers.
+
+Never commit secrets. Service account JSON stays outside the repo.
+
+Keep PRs small and focused. Update tests and docs with code changes.
+
+Always run preflight before pushing.
+
+Environment variables for local runs and CI (do not commit secrets)
+OSRM_BASE_URL=http://localhost:5000
+
+NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
+
+GEOCODE_USER_AGENT=SmokeAlarmBot/1.0 (contact@example.com
+)
+GEOCODE_RPS=1
+GOOGLE_SA_PATH=.secrets/service_account.json
+APPRISE_URLS=
+API_TOKEN=
+PYTHONPATH=agent/src
+
+Setup (use uv if available, else pip)
+uv pip install --system -U pip
+uv pip install --system -r requirements.txt || true
+uv pip install --system ruff mypy pytest pytest-xdist coverage pytest-cov hypothesis bandit pip-audit deptry pipdeptree pre-commit nox
+pre-commit install
+pre-commit install --hook-type pre-push
+
+Optional local OSRM for Australia. Prefer this to public demo.
+Put australia-latest.osm.pbf in ./data then run:
+docker run -t -v $(pwd)/data:/data osrm/osrm-backend osrm-extract -p /opt/car.lua /data/australia-latest.osm.pbf
+docker run -t -v $(pwd)/data:/data osrm/osrm-backend osrm-partition /data/australia-latest.osrm
+docker run -t -v $(pwd)/data:/data osrm/osrm-backend osrm-customize /data/australia-latest.osrm
+docker run -p 5000:5000 -t -v $(pwd)/data:/data osrm/osrm-backend osrm-routed --algorithm mld /data/australia-latest.osrm
+
+Daily preflight
+ruff check . --fix
+ruff format .
+mypy .
+pytest -n auto --cov=agent --cov-report=term
+bandit -q -r agent -x tests
+pip-audit -r requirements.txt --strict || true
+deptry
+
+Git hygiene
+git fetch origin
+git rebase origin/main
+git grep -n -E '^(<{7}|={7}|>{7}||{7})' -- . && exit 1
+
+Stable entry points
+CLI route planning:
+python -m agent.cli route --date YYYY-MM-DD --responses-file path/to/jobs.csv
+Optional flags if present:
+--vehicles N
+--shift-start HH:MM
+--shift-end HH:MM
+--max-visits-per-tech N
+--output pdf|csv|sheet
+
+Service rules
+
+Geocoding uses NOMINATIM_BASE_URL and GEOCODE_USER_AGENT and obeys GEOCODE_RPS.
+
+Routing uses OSRM_BASE_URL. Do not use the public OSRM demo in production.
+
+Sheets uses gspread with GOOGLE_SA_PATH. Share the sheet with that SA email.
+
+Reports render with Jinja2 templates in templates and WeasyPrint for PDF.
+
+UI starts with: streamlit run gui/streamlit_app.py
+
+API if enabled runs at agent/src/agent/api/main.py and uses API_TOKEN header.
+
+Coding standards
+
+Ruff rules from pyproject.toml
+
+mypy strict mode
+
+Prefer pure functions and small modules
+
+Log with structured messages and include correlation ids where helpful
+
+Do not modify without reason
+
+.github/workflows steps that enforce lint, type, tests
+
+.secrets directory and any secret files
+
+LICENSE
+
+Commit and PR rules
+
+Conventional commits
+
+PR must include what changed, why, and test evidence
+
+PR must pass CI and be up to date with origin/main
+
+Self checks before opening a PR
+ruff check . --fix && ruff format .
+mypy .
+pytest -n auto --cov=agent --cov-report=term
+pip-audit -r requirements.txt --strict || true
+git fetch origin && git merge-base --is-ancestor origin/main HEAD
+git grep -n -E '^(<{7}|={7}|>{7}||{7})' -- . || echo "No conflict markers"
+
+Nested AGENTS.md
+Add scoped AGENTS.md files inside key subfolders to refine rules for that area. The root file stays the source of truth. Keep nested files short and consistent.

--- a/agent/AGENTS.md
+++ b/agent/AGENTS.md
@@ -1,0 +1,65 @@
+AGENTS.md (agent)
+
+Scope: Python package code under agent.
+
+Module map
+
+src/agent/cli.py CLI entry points
+
+src/agent/services OSRM client, geocode adapter, sheets sync, notifications
+
+src/agent/optimizer VRP and time window solver
+
+src/agent/reports.py HTML to PDF reports
+
+tests unit and integration tests
+
+Contracts
+
+Python 3.11 or newer
+
+All public functions and data models are type hinted
+
+Use Pydantic models for external IO and configs
+
+Use requests or httpx with timeouts and retry policy
+
+Error policy
+
+Fail fast for missing env or required columns
+
+Wrap external HTTP errors with clear messages
+
+Never swallow exceptions silently
+
+Return value must not be None unless documented
+
+Performance
+
+Cache OSRM table calls when matrix size repeats
+
+Rate limit geocoding at 1 rps
+
+Keep cold start under 2 seconds for CLI
+
+Logging
+
+Use logging.getLogger(name)
+
+Include route id or batch id in log context where possible
+
+Testing
+
+Unit tests in agent/tests for each module
+
+Use Hypothesis for parsers and small pure functions
+
+Use pytest markers to skip slow tests by default
+
+Acceptance
+
+ruff and mypy pass
+
+CLI route command works against a small sample csv
+
+Reports render a valid PDF in build folder

--- a/agent/src/agent/optimizer/AGENTS.md
+++ b/agent/src/agent/optimizer/AGENTS.md
@@ -1,0 +1,47 @@
+AGENTS.md (optimizer)
+
+Scope: VRP and time window optimization.
+
+Inputs
+
+Jobs with lat lon service time and optional time window
+
+Vehicles with shift start, shift end, and capacity
+
+Depot coordinate
+
+Travel time matrix in seconds from OSRM /table
+
+Rules
+
+Use OR-Tools RoutingModel and time window constraints
+
+Deterministic seed
+
+Respect vehicle shift windows
+
+Allow hard or soft time windows configurable
+
+If solver fails, return a clear error and a fallback nearest neighbor plan
+
+Performance targets
+
+Up to 200 jobs and 10 vehicles on a laptop within a few seconds to a minute
+
+Matrix build is the main cost so cache by day and depot
+
+Tests
+
+Unit test for cost functions and constraints
+
+Golden tests for small synthetic days
+
+Property tests for trivial cases such as one job per vehicle
+
+Outputs
+
+Ordered stops per vehicle with arrival and departure times
+
+Total drive time and service time
+
+Google Maps share links for each vehicle path

--- a/agent/src/agent/services/AGENTS.md
+++ b/agent/src/agent/services/AGENTS.md
@@ -1,0 +1,49 @@
+AGENTS.md (agent services)
+
+Scope: service modules that talk to external systems.
+
+OSRM client
+
+Base URL from OSRM_BASE_URL
+
+Use /table for matrix and /route for geometry and ETA
+
+Timeout 5 seconds per request
+
+Retries with backoff for transient errors
+
+Strict schema for responses
+
+Never call the public OSRM demo in production
+
+Geocoding
+
+Base URL from NOMINATIM_BASE_URL
+
+Always send GEOCODE_USER_AGENT
+
+Rate limit using GEOCODE_RPS
+
+Retries with backoff
+
+Cache successful results on disk or in memory
+
+Sheets
+
+Use gspread with service account at GOOGLE_SA_PATH
+
+Read jobs by date and write back assignments and ETAs only in allowed columns
+
+Handle network failures with retries and idempotent writes
+
+Notifications
+
+Use Apprise URLs from APPRISE_URLS
+
+Support dry run mode for tests
+
+Testing
+
+Mock HTTP at module boundary
+
+Add integration tests that hit localhost OSRM if available

--- a/gui/AGENTS.md
+++ b/gui/AGENTS.md
@@ -1,0 +1,28 @@
+AGENTS.md (gui)
+
+Scope: Streamlit dispatcher UI.
+
+Run
+streamlit run gui/streamlit_app.py
+
+UI rules
+
+Inputs for day, vehicles, shift bounds
+
+Show table of jobs and current plan
+
+Button Optimize that calls solver through python or API
+
+Map preview of plan
+
+Links to Google Maps for crews
+
+No secrets in code. Read from env only.
+
+Keep first contentful paint fast. Cache OSRM table and geocodes where possible.
+
+Tests
+
+Keep logic in pure functions and test them in agent tests
+
+UI smoke test can run in CI with headless mode if practical


### PR DESCRIPTION
## Summary
- document repo-wide build, test, and PR rules for coding agents
- add scoped service, optimizer, and gui instructions
- configure GitHub Copilot to defer to AGENTS guidance

## Testing
- `ruff check . --fix` *(fails: invalid syntax in existing files)*
- `ruff format .` *(fails: parse errors in existing files)*
- `mypy .` *(fails: unindent does not match any outer indentation level)*
- `pytest -n auto --cov=agent --cov-report=term` *(fails: unrecognized arguments: -n --cov=agent --cov-report=term)*
- `pip-audit -r requirements.txt --strict || true` *(fails: command not found)*
- `git fetch origin && git merge-base --is-ancestor origin/main HEAD` *(fails: 'origin' does not appear to be a git repository)*
- `git grep -n -E '^(<{7}|={7}|>{7}||{7})' -- . || echo "No conflict markers"` *(fails: Invalid preceding regular expression)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9de456048324b48485c07e301067